### PR TITLE
ensures ACL resource exists if ACL link header is present on PUT/POST

### DIFF
--- a/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
+++ b/fcrepo-http-api/src/test/java/org/fcrepo/integration/http/api/FedoraVersioningIT.java
@@ -90,8 +90,20 @@ public class FedoraVersioningIT extends AbstractResourceIT {
     @Test
     public void testDeleteTimeMapForContainer() throws Exception {
         createVersionedContainer(id, subjectUri);
+
+        final String mementoUri = createMemento(subjectUri, null, null, null);
+        assertEquals(200, getStatus(new HttpGet(mementoUri)));
+
+        final String timeMapUri = subjectUri + "/" + FCR_VERSIONS;
+        assertEquals(200, getStatus(new HttpGet(timeMapUri)));
+
         // disabled versioning to delete TimeMap
         assertEquals(NO_CONTENT.getStatusCode(), getStatus(new HttpDelete(serverAddress + id + "/" + FCR_VERSIONS)));
+
+        // validate that the memento version is gone
+        assertEquals(404, getStatus(new HttpGet(mementoUri)));
+        // validate that the LDPCv is gone
+        assertEquals(404, getStatus(new HttpGet(timeMapUri)));
     }
 
     @Test

--- a/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/InvalidACLExceptionMapper.java
+++ b/fcrepo-http-commons/src/main/java/org/fcrepo/http/commons/exceptionhandlers/InvalidACLExceptionMapper.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.http.commons.exceptionhandlers;
+
+import static javax.ws.rs.core.Response.status;
+import static javax.ws.rs.core.Response.Status.CONFLICT;
+import static org.fcrepo.http.commons.domain.RDFMediaType.TEXT_PLAIN_WITH_CHARSET;
+import static org.slf4j.LoggerFactory.getLogger;
+
+import javax.servlet.ServletContext;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Link;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+import org.fcrepo.kernel.api.exception.InvalidACLException;
+import org.slf4j.Logger;
+
+/**
+ * Translate InvalidACLExceptions into HTTP 409 CONFLICT errors
+ *
+ * @author harring
+ * @since 2018-03-13
+ */
+public class InvalidACLExceptionMapper extends ConstraintExceptionMapper<InvalidACLException>
+        implements ExceptionDebugLogging {
+
+    private static final Logger LOGGER = getLogger(InvalidACLExceptionMapper.class);
+
+    @Context
+    private UriInfo uriInfo;
+
+    @Context
+    private ServletContext context;
+
+    @Override
+    public Response toResponse(final InvalidACLException e) {
+        debugException(this, e, LOGGER);
+        final Link link = buildConstraintLink(e, context, uriInfo);
+        final String msg = e.getMessage();
+        return status(CONFLICT).entity(msg).links(link).type(TEXT_PLAIN_WITH_CHARSET).build();
+    }
+
+}

--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/InvalidACLException.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/exception/InvalidACLException.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to DuraSpace under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional information
+ * regarding copyright ownership.
+ *
+ * DuraSpace licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except in
+ * compliance with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.fcrepo.kernel.api.exception;
+
+/**
+ *
+ * @author harring
+ * @since 2018-03-13
+ */
+public class InvalidACLException extends ConstraintViolationException {
+
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Ordinary constructor.
+     *
+     * @param msg the message
+     */
+    public InvalidACLException(final String msg) {
+        super(msg);
+    }
+
+    /**
+     * Ordinary constructor.
+     *
+     * @param rootCause the root cause
+     */
+    public InvalidACLException(final Throwable rootCause) {
+        super(rootCause);
+    }
+
+}

--- a/fcrepo-webapp/src/main/webapp/static/constraints/InvalidACLException.rdf
+++ b/fcrepo-webapp/src/main/webapp/static/constraints/InvalidACLException.rdf
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="owl2html.xsl"?>
+
+<!DOCTYPE rdf:RDF [
+    <!ENTITY owl "http://www.w3.org/2002/07/owl#" >
+    <!ENTITY xsd "http://www.w3.org/2001/XMLSchema#" >
+    <!ENTITY rdfs "http://www.w3.org/2000/01/rdf-schema#" >
+    <!ENTITY rdf "http://www.w3.org/1999/02/22-rdf-syntax-ns#" >
+]>
+
+
+<rdf:RDF
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <owl:Ontology rdf:about="static/constraints/InvalidACLException">
+        <rdfs:label xml:lang="en">Invalid ACL Exception</rdfs:label>
+        <rdfs:comment xml:lang="en">Fedora wasn't able to create the LDPR with the specified LDP-RS as the ACL. Either
+        the ACL URI in the link header does not exist or exists but does not contain a triple indicating rdf:type of
+        http://fedora.info/definitions/v4/webac#Acl
+        </rdfs:comment>
+    </owl:Ontology>
+</rdf:RDF>


### PR DESCRIPTION
- adds InvalidACLException and InvalidACLExceptionMapper classes
- adds InvalidACLException.rdf
- updates FedoraLdp

Resolves: https://jira.duraspace.org/browse/FCREPO-2705