### PR TITLE
Fcrepo 2723: If acl URI exists but does not contain the correct triple, return 409

### DIFF
--- a/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/RdfLexicon.java
+++ b/fcrepo-kernel-api/src/main/java/org/fcrepo/kernel/api/RdfLexicon.java
@@ -64,6 +64,8 @@ public final class RdfLexicon {
      * Namespace for the W3C WebAC vocabulary.
      */
     public static final String WEBAC_NAMESPACE_VALUE = "http://www.w3.org/ns/auth/acl#";
+    public static final String FEDORA_WEBAC_NAMESPACE_VALUE = "http://fedora.info/definitions/v4/webac#";
+    public static final String FEDORA_WEBAC_ACL_VALUE = FEDORA_WEBAC_NAMESPACE_VALUE + "Acl";
 
     /**
      * Fedora configuration namespace "fedora-config", used for user-settable


### PR DESCRIPTION
- updates FedoraLdp to return 409 in case acl resource doesn’t have
type web:Acl

-  updates private createAcl() method in FedoraLdpIT to add the
required type to an acl and adds second private method to test for
cases where type is not present

- adds unique id to aclPid for each test

- adds slug to new POST tests for consistency

Resolves: https://jira.duraspace.org/browse/FCREPO-2723